### PR TITLE
Clean up additional files generated by foreground-child watchdog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^1.2.0",
         "find-cache-dir": "^3.2.0",
         "find-up": "^4.1.0",
-        "foreground-child": "^3.0.0",
+        "foreground-child": "^3.3.0",
         "get-package-type": "^0.1.0",
         "glob": "^7.1.6",
         "istanbul-lib-coverage": "^3.0.0",
@@ -4911,9 +4911,9 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "decamelize": "^1.2.0",
     "find-cache-dir": "^3.2.0",
     "find-up": "^4.1.0",
-    "foreground-child": "^3.0.0",
+    "foreground-child": "^3.3.0",
     "get-package-type": "^0.1.0",
     "glob": "^7.1.6",
     "istanbul-lib-coverage": "^3.0.0",

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -193,9 +193,7 @@ t.test('interprets first args after -- as Node.js execArgv', t => testSuccess(t,
   args: ['--', '--expose-gc', path.resolve(fixturesCLI, 'gc.js')]
 }))
 
-// TODO; get this test to pass with `foreground-child@^3.0.0` or delete.
-// See https://github.com/istanbuljs/nyc/pull/1546
-t.skip('--show-process-tree displays a tree of spawned processes', t => testSuccess(t, {
+t.test('--show-process-tree displays a tree of spawned processes', t => testSuccess(t, {
   args: ['--show-process-tree', process.execPath, 'selfspawn-fibonacci.js', '5']
 }))
 

--- a/test/processinfo.js
+++ b/test/processinfo.js
@@ -16,12 +16,7 @@ const resolvedJS = resolve(fixturesCLI, 'selfspawn-fibonacci.js')
 rimraf.sync(resolve(fixturesCLI, tmp))
 t.teardown(() => rimraf(resolve(fixturesCLI, tmp)))
 
-// TODO; get this test to pass with `foreground-child@^3.0.0` or delete.
-// See https://github.com/istanbuljs/nyc/pull/1546
-//
-// The subprocess is failing with the following error:
-// " External ID blorp used by multiple processes"
-t.skip('build some processinfo', t => {
+t.test('build some processinfo', t => {
   var args = [
     bin, '-t', tmp,
     node, 'selfspawn-fibonacci.js', '5'
@@ -43,8 +38,7 @@ t.skip('build some processinfo', t => {
   })
 })
 
-// This test is skipped because it relies on the above "build some processinfo" test.
-t.skip('validate the created processinfo data', async t => {
+t.test('validate the created processinfo data', async t => {
   const covs = (await fs.readdir(resolve(fixturesCLI, tmp)))
     .filter(f => f !== 'processinfo')
 
@@ -73,8 +67,7 @@ t.skip('validate the created processinfo data', async t => {
   }))
 })
 
-// This test is skipped because it relies on the above "build some processinfo" test.
-t.skip('check out the index', async t => {
+t.test('check out the index', async t => {
   const indexFile = resolve(fixturesCLI, tmp, 'processinfo', 'index.json')
   const indexJson = await fs.readFile(indexFile, 'utf-8')
   const index = JSON.parse(indexJson)

--- a/test/temp-dir.js
+++ b/test/temp-dir.js
@@ -33,7 +33,7 @@ t.test('creates the default \'tempDir\' when none is specified', async t => {
   t.equal(cliFiles.includes('.temp_directory'), false)
 
   const tempFiles = await fs.readdir(path.resolve(fixturesCLI, '.nyc_output'))
-  t.equal(tempFiles.length, 3) // two coverage files, and processinfo
+  t.equal(tempFiles.length, 2) // a coverage file, and processinfo
 })
 
 t.test('prefers \'tempDirectory\' to \'tempDir\'', async t => {
@@ -56,7 +56,7 @@ t.test('prefers \'tempDirectory\' to \'tempDir\'', async t => {
   t.equal(cliFiles.includes('.temp_directory'), true)
 
   const tempFiles = await fs.readdir(path.resolve(fixturesCLI, '.temp_directory'))
-  t.equal(tempFiles.length, 3)
+  t.equal(tempFiles.length, 2)
 })
 
 t.test('uses the \'tempDir\' option if \'tempDirectory\' is not set', async t => {
@@ -77,5 +77,5 @@ t.test('uses the \'tempDir\' option if \'tempDirectory\' is not set', async t =>
   t.equal(cliFiles.includes('.temp_directory'), false)
 
   const tempFiles = await fs.readdir(path.resolve(fixturesCLI, '.temp_dir'))
-  t.equal(tempFiles.length, 3)
+  t.equal(tempFiles.length, 2)
 })


### PR DESCRIPTION
This PR cleans up the additional files created due to foreground-child 3.x's watchdog process when nyc runs.

It also reverts changes to the (skipped + commented) tests, so it should run all the tests as they are in nyc's `main` no problem